### PR TITLE
Partial swf fix

### DIFF
--- a/WallyMapSpinzor2.Raylib/src/Editor.cs
+++ b/WallyMapSpinzor2.Raylib/src/Editor.cs
@@ -39,7 +39,7 @@ public class Editor
 
     private readonly RenderConfig _config = new()
     {
-        RedScore = 48,
+        RedScore = 4,
         BlueScore = 11
     };
 

--- a/WallyMapSpinzor2.Raylib/src/Editor.cs
+++ b/WallyMapSpinzor2.Raylib/src/Editor.cs
@@ -39,8 +39,7 @@ public class Editor
 
     private readonly RenderConfig _config = new()
     {
-        RedScore = 4,
-        BlueScore = 11
+        
     };
 
     public void Run()

--- a/WallyMapSpinzor2.Raylib/src/Editor.cs
+++ b/WallyMapSpinzor2.Raylib/src/Editor.cs
@@ -39,7 +39,7 @@ public class Editor
 
     private readonly RenderConfig _config = new()
     {
-
+        RedScore = 18
     };
 
     public void Run()

--- a/WallyMapSpinzor2.Raylib/src/Editor.cs
+++ b/WallyMapSpinzor2.Raylib/src/Editor.cs
@@ -39,7 +39,8 @@ public class Editor
 
     private readonly RenderConfig _config = new()
     {
-        RedScore = 18
+        RedScore = 48,
+        BlueScore = 11
     };
 
     public void Run()

--- a/WallyMapSpinzor2.Raylib/src/RaylibCanvas.cs
+++ b/WallyMapSpinzor2.Raylib/src/RaylibCanvas.cs
@@ -27,7 +27,7 @@ public class RaylibCanvas : ICanvas<Texture2DWrapper>
     public Dictionary<string, Texture2DWrapper> TextureCache { get; } = new();
     public Dictionary<string, SwfCache> SwfFileCache { get; } = new();
     public Dictionary<(string, string), Texture2DWrapper> SwfTextureCache { get; } = new();
-    public Dictionary<Texture2DWrapper, (double, double)> TextureOffset { get; } = new();
+    public Dictionary<Texture2DWrapper, Transform> TextureTransform { get; } = new();
     public Matrix4x4 CameraMatrix { get; set; } = Matrix4x4.Identity;
 
     public RaylibCanvas(string brawlPath)
@@ -132,9 +132,8 @@ public class RaylibCanvas : ICanvas<Texture2DWrapper>
     {
         if (texture.Texture is null) return;
         
-        (double xOff, double yOff) = TextureOffset.GetValueOrDefault(texture, (0, 0));
-        
-        trans = trans * Transform.CreateTranslate(xOff, yOff);
+        Transform textureTrans = TextureTransform.GetValueOrDefault(texture, Transform.IDENTITY);
+        trans = trans * textureTrans;
         
         Texture2D rlTexture = (Texture2D)texture.Texture;
         DrawingQueue.Push(() =>
@@ -146,6 +145,10 @@ public class RaylibCanvas : ICanvas<Texture2DWrapper>
     public void DrawTextureRect(double x, double y, double w, double h, Texture2DWrapper texture, Transform trans, DrawPriorityEnum priority)
     {
         if (texture.Texture is null) return;
+        
+        Transform textureTrans = TextureTransform.GetValueOrDefault(texture, Transform.IDENTITY);
+        trans = trans * textureTrans;
+        
         Texture2D rlTexture = (Texture2D)texture.Texture;
         DrawingQueue.Push(() =>
         {
@@ -230,13 +233,13 @@ public class RaylibCanvas : ICanvas<Texture2DWrapper>
             SwfFileCache.Add(finalPath, cache);
         }
 
-        (Texture2DWrapper swfTexture, double xOff, double yOff) = LoadTextureFromSwf(cache, name);
+        (Texture2DWrapper swfTexture, Transform trans) = LoadTextureFromSwf(cache, name);
         SwfTextureCache.Add((finalPath, name), swfTexture);
-        TextureOffset.Add(swfTexture, (xOff, yOff));
+        TextureTransform.Add(swfTexture, trans);
         return swfTexture;
     }
 
-    private static (Texture2DWrapper, double, double) LoadTextureFromSwf(SwfCache swf, string name)
+    private static (Texture2DWrapper, Transform) LoadTextureFromSwf(SwfCache swf, string name)
     {
         ushort spriteId = swf.SymbolClass[name];
         DefineSpriteTag sprite = swf.SpriteTags[spriteId];
@@ -253,7 +256,8 @@ public class RaylibCanvas : ICanvas<Texture2DWrapper>
         using MemoryStream ms = new();
         image.SaveAsPng(ms);
         Raylib_cs.Image img = Rl.LoadImageFromMemory(".png", ms.ToArray());
-        return (new Texture2DWrapper(Rl.LoadTextureFromImage(img)), shape.ShapeBounds.XMin, shape.ShapeBounds.YMin);
+        Transform trans = Transform.CreateScale(0.05, 0.05) * Transform.CreateTranslate(x: shape.ShapeBounds.XMin, y: shape.ShapeBounds.YMin);
+        return (new Texture2DWrapper(Rl.LoadTextureFromImage(img)), trans);
     }
 
     private static SwfCache LoadSwf(string path)


### PR DESCRIPTION
Almost fixes swf drawing. Now properly takes into account the shape's offset. Scoreboard digits are still not fully correct, but they're atleast MORE correct.

Also contains a commit to make it possible to display maps without a LevelType.