### PR TITLE
made jpg loading be done into qoi instead of png

### DIFF
--- a/WallyMapSpinzor2.Raylib/src/SwfTextureCache.cs
+++ b/WallyMapSpinzor2.Raylib/src/SwfTextureCache.cs
@@ -65,8 +65,8 @@ public class SwfTextureCache
         ImageSharpShapeExporter exporter = new(image, new IMS.Size(-shape.ShapeBounds.XMin, -shape.ShapeBounds.YMin));
         compiledShape.Export(exporter);
         using MemoryStream ms = new();
-        image.SaveAsPng(ms);
-        Raylib_cs.Image img = Rl.LoadImageFromMemory(".png", ms.ToArray());
+        image.SaveAsQoi(ms);
+        Raylib_cs.Image img = Rl.LoadImageFromMemory(".qoi", ms.ToArray());
         Transform trans = Transform.CreateScale(0.05, 0.05) * Transform.CreateTranslate(x: shape.ShapeBounds.XMin, y: shape.ShapeBounds.YMin);
         return (img, trans);
     }

--- a/WallyMapSpinzor2.Raylib/src/Utils.cs
+++ b/WallyMapSpinzor2.Raylib/src/Utils.cs
@@ -36,8 +36,8 @@ public static class Utils
         {
             using Image image = Image.Load(path);
             using MemoryStream ms = new();
-            image.SaveAsPng(ms);
-            return Rl.LoadImageFromMemory(".png", ms.ToArray());
+            image.SaveAsQoi(ms);
+            return Rl.LoadImageFromMemory(".qoi", ms.ToArray());
         }
 
         return Rl.LoadImage(path);


### PR DESCRIPTION
load jpg into qoi instead of png. this speeds up the background loading from ~4 seconds to ~2 seconds.
more memory usage, but it's just for a short period of time when opening the program, so should be fine.