### PR TITLE
unify the texture caches into a generic abstract class

### DIFF
--- a/WallyMapSpinzor2.Raylib/src/Cache/ManagedCache.cs
+++ b/WallyMapSpinzor2.Raylib/src/Cache/ManagedCache.cs
@@ -6,7 +6,7 @@ namespace WallyMapSpinzor2.Raylib;
 
 public abstract class ManagedCache<K, V> where K : notnull
 {
-    public ConcurrentDictionary<K, V> Cache { get; } = new();
+    public ConcurrentDictionary<K, V> Cache { get; } = [];
     private readonly HashSet<K> _loading = [];
 
     protected abstract V LoadInternal(K k);

--- a/WallyMapSpinzor2.Raylib/src/Cache/TextureCache.cs
+++ b/WallyMapSpinzor2.Raylib/src/Cache/TextureCache.cs
@@ -1,72 +1,27 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 using Raylib_cs;
 using Rl = Raylib_cs.Raylib;
 
 namespace WallyMapSpinzor2.Raylib;
 
-public class TextureCache
+public class TextureCache : UploadCache<string, Image, Texture2DWrapper>
 {
-    public ConcurrentDictionary<string, Texture2DWrapper> Cache { get; } = new();
-    private readonly Queue<(string, Image)> _queue = new();
-    private readonly HashSet<string> _queueSet = [];
-
-    public void LoadTexture(string path)
+    protected override Image LoadIntermediate(string path)
     {
-        Image img = Utils.LoadRlImage(path);
-        Texture2D texture = Rl.LoadTextureFromImage(img);
-        Cache[path] = new(texture);
+        return Utils.LoadRlImage(path);
+    }
+
+    protected override Texture2DWrapper IntermediateToValue(Image img)
+    {
+        return new(Rl.LoadTextureFromImage(img));
+    }
+
+    protected override void UnloadIntermediate(Image img)
+    {
         Rl.UnloadImage(img);
     }
 
-    public void LoadImageAsync(string path)
+    protected override void UnloadValue(Texture2DWrapper texture)
     {
-        if (_queueSet.Contains(path)) return;
-        _queueSet.Add(path);
-
-        Task.Run(() =>
-        {
-            Image img = Utils.LoadRlImage(path);
-            lock (_queue) _queue.Enqueue((path, img));
-        });
-    }
-
-    public void UploadImages(int amount)
-    {
-        lock (_queue)
-        {
-            amount = Math.Clamp(amount, 0, _queue.Count);
-            for (int i = 0; i < amount; i++)
-            {
-                (string path, Image img) = _queue.Dequeue();
-                _queueSet.Remove(path);
-                if (!Cache.ContainsKey(path))
-                {
-                    Texture2D texture = Rl.LoadTextureFromImage(img);
-                    Cache[path] = new(texture);
-                }
-                Rl.UnloadImage(img);
-            }
-        }
-    }
-
-    public void Clear()
-    {
-        foreach ((_, Texture2DWrapper txt) in Cache)
-            txt.Dispose();
-        Cache.Clear();
-
-        _queueSet.Clear();
-        lock (_queue)
-        {
-            while (_queue.Count > 0)
-            {
-                (_, Image img) = _queue.Dequeue();
-                Rl.UnloadImage(img);
-            }
-        }
+        texture.Dispose();
     }
 }

--- a/WallyMapSpinzor2.Raylib/src/Cache/UploadCache.cs
+++ b/WallyMapSpinzor2.Raylib/src/Cache/UploadCache.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -7,7 +6,7 @@ namespace WallyMapSpinzor2.Raylib;
 
 public abstract class UploadCache<K, I, V> where K : notnull
 {
-    public ConcurrentDictionary<K, V> Cache { get; } = new();
+    public Dictionary<K, V> Cache { get; } = [];
     private readonly Queue<(K, I)> _queue = [];
     private readonly HashSet<K> _queueSet = [];
 

--- a/WallyMapSpinzor2.Raylib/src/Cache/UploadCache.cs
+++ b/WallyMapSpinzor2.Raylib/src/Cache/UploadCache.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WallyMapSpinzor2.Raylib;
+
+public abstract class UploadCache<K, I, V> where K : notnull
+{
+    public ConcurrentDictionary<K, V> Cache { get; } = new();
+    private readonly Queue<(K, I)> _queue = [];
+    private readonly HashSet<K> _queueSet = [];
+
+    protected abstract I LoadIntermediate(K k);
+    protected abstract V IntermediateToValue(I i);
+    protected abstract void UnloadIntermediate(I i);
+    protected abstract void UnloadValue(V v);
+
+    public void Load(K k)
+    {
+        I i = LoadIntermediate(k);
+        V v = IntermediateToValue(i);
+        UnloadIntermediate(i);
+        Cache[k] = v;
+    }
+
+    public void LoadAsync(K k)
+    {
+        if (_queueSet.Contains(k)) return;
+        _queueSet.Add(k);
+
+        Task.Run(() =>
+        {
+            I i = LoadIntermediate(k);
+            lock (_queue) _queue.Enqueue((k, i));
+        });
+    }
+
+    public void Upload(int amount)
+    {
+        lock (_queue)
+        {
+            amount = Math.Clamp(amount, 0, _queue.Count);
+            for (int j = 0; j < amount; j++)
+            {
+                (K k, I i) = _queue.Dequeue();
+                _queueSet.Remove(k);
+                if (!Cache.ContainsKey(k))
+                {
+                    V v = IntermediateToValue(i);
+                    Cache[k] = v;
+                }
+                UnloadIntermediate(i);
+            }
+        }
+    }
+
+    public void Clear()
+    {
+        foreach ((_, V v) in Cache)
+            UnloadValue(v);
+        Cache.Clear();
+
+        _queueSet.Clear();
+        lock (_queue)
+        {
+            while (_queue.Count > 0)
+            {
+                (_, I i) = _queue.Dequeue();
+                UnloadIntermediate(i);
+            }
+        }
+    }
+}

--- a/WallyMapSpinzor2.Raylib/src/RaylibCanvas.cs
+++ b/WallyMapSpinzor2.Raylib/src/RaylibCanvas.cs
@@ -209,7 +209,7 @@ public partial class RaylibCanvas : ICanvas
         TextureCache.Cache.TryGetValue(finalPath, out Texture2DWrapper? texture);
         if (texture is not null) return texture;
 
-        TextureCache.LoadImageAsync(finalPath);
+        TextureCache.LoadAsync(finalPath);
         return Texture2DWrapper.Default; // placeholder white texture until the image is read from disk
     }
 
@@ -231,7 +231,7 @@ public partial class RaylibCanvas : ICanvas
         SwfShapeCache.Cache.TryGetValue((swf, shapeId, animScale), out Texture2DWrapper? texture);
         if (texture is not null)
             return texture;
-        SwfShapeCache.LoadShapeAsync(swf, shapeId, animScale);
+        SwfShapeCache.LoadAsync(swf, shapeId, animScale);
         return null;
     }
 
@@ -251,8 +251,8 @@ public partial class RaylibCanvas : ICanvas
     public const int MAX_SWF_TEXTURE_UPLOADS_PER_FRAME = 5;
     public void FinalizeDraw()
     {
-        TextureCache.UploadImages(MAX_TEXTURE_UPLOADS_PER_FRAME);
-        SwfShapeCache.UploadImages(MAX_SWF_TEXTURE_UPLOADS_PER_FRAME);
+        TextureCache.Upload(MAX_TEXTURE_UPLOADS_PER_FRAME);
+        SwfShapeCache.Upload(MAX_SWF_TEXTURE_UPLOADS_PER_FRAME);
 
         while (DrawingQueue.Count > 0)
         {


### PR DESCRIPTION
also moves the cache dictionaries to be Dictionary instead of ConcurrentDictionary - we were only editing the cache in the Upload function which runs in main thread