### PR TITLE
Implement brawlhalla-consistent xml parsing and outputing

### DIFF
--- a/WallyMapSpinzor2.Raylib/src/Editor.cs
+++ b/WallyMapSpinzor2.Raylib/src/Editor.cs
@@ -326,7 +326,7 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
         if (btPath is not null)
         {
             using FileStream bonesFile = new(btPath, FileMode.Open, FileAccess.Read);
-            BoneNames = [.. XElement.Load(bonesFile).Elements("Bone").Select(e => e.Value)];
+            BoneNames = [.. BhXmlParser.Load(bonesFile).Elements("Bone").Select(e => e.Value)];
         }
         PowerNames = ptPath is not null ? Wms2RlUtils.ParsePowerTypes(File.ReadAllText(ptPath)) : null;
         LevelDesc ld = Wms2RlUtils.DeserializeFromPath<LevelDesc>(ldPath);

--- a/WallyMapSpinzor2.Raylib/src/Editor.cs
+++ b/WallyMapSpinzor2.Raylib/src/Editor.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Numerics;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Xml.Linq;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -329,9 +327,9 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
             BoneNames = [.. BhXmlParser.Load(bonesFile).Elements("Bone").Select(e => e.Value)];
         }
         PowerNames = ptPath is not null ? Wms2RlUtils.ParsePowerTypes(File.ReadAllText(ptPath)) : null;
-        LevelDesc ld = Wms2RlUtils.DeserializeFromPath<LevelDesc>(ldPath);
-        LevelTypes lt = ltPath is null ? new() { Levels = [] } : Wms2RlUtils.DeserializeFromPath<LevelTypes>(ltPath);
-        LevelSetTypes lst = lstPath is null ? new() { Playlists = [] } : Wms2RlUtils.DeserializeFromPath<LevelSetTypes>(lstPath);
+        LevelDesc ld = Wms2RlUtils.DeserializeFromPath<LevelDesc>(ldPath, bhstyle: true);
+        LevelTypes lt = ltPath is null ? new() { Levels = [] } : Wms2RlUtils.DeserializeFromPath<LevelTypes>(ltPath, bhstyle: true);
+        LevelSetTypes lst = lstPath is null ? new() { Playlists = [] } : Wms2RlUtils.DeserializeFromPath<LevelSetTypes>(lstPath, bhstyle: true);
 
         // scuffed xml parse error handling
         if (ld.CameraBounds is null) throw new System.Xml.XmlException("LevelDesc xml did not contain essential elements");

--- a/WallyMapSpinzor2.Raylib/src/Gui/Windows/ExportWindow.cs
+++ b/WallyMapSpinzor2.Raylib/src/Gui/Windows/ExportWindow.cs
@@ -324,14 +324,14 @@ public class ExportWindow(PathPreferences prefs)
 
         if (ImGuiExt.WithDisabledButton(string.IsNullOrEmpty(prefs.LevelSetTypesPath), "Export##lst"))
         {
-            LevelSetTypes levelSetTypes = Wms2RlUtils.DeserializeFromPath<LevelSetTypes>(prefs.LevelSetTypesPath!);
+            LevelSetTypes levelSetTypes = Wms2RlUtils.DeserializeFromPath<LevelSetTypes>(prefs.LevelSetTypesPath!, bhstyle: true);
             UpdatePlaylists(levelSetTypes, l);
 
             Task.Run(() =>
             {
                 DialogResult result = Dialog.FileSave("xml", Path.GetDirectoryName(prefs.LevelSetTypesPath));
                 if (result.IsOk)
-                    Wms2RlUtils.SerializeToPath(levelSetTypes, result.Path);
+                    Wms2RlUtils.SerializeToPath(levelSetTypes, result.Path, bhstyle: true);
             });
         }
     }
@@ -379,9 +379,9 @@ public class ExportWindow(PathPreferences prefs)
         Dictionary<string, string> gameFiles = [];
         foreach (string content in Wms2RlUtils.GetFilesInSwz(gamePath, key))
             gameFiles.Add(SwzUtils.GetFileName(content), content);
-        LevelSetTypes lst = Wms2RlUtils.DeserializeFromString<LevelSetTypes>(gameFiles["LevelSetTypes.xml"]);
+        LevelSetTypes lst = Wms2RlUtils.DeserializeFromString<LevelSetTypes>(gameFiles["LevelSetTypes.xml"], bhstyle: true);
         UpdatePlaylists(lst, l);
-        gameFiles["LevelSetTypes.xml"] = Wms2RlUtils.SerializeToString(lst, true);
+        gameFiles["LevelSetTypes.xml"] = Wms2RlUtils.SerializeToString(lst, minify: true, bhstyle: true);
 
         _exportStatus = "creating new swz...";
         Wms2RlUtils.SerializeSwzFilesToPath(dynamicPath, dynamicFiles.Values, key);

--- a/WallyMapSpinzor2.Raylib/src/Gui/Windows/ExportWindow.cs
+++ b/WallyMapSpinzor2.Raylib/src/Gui/Windows/ExportWindow.cs
@@ -205,7 +205,7 @@ public class ExportWindow(PathPreferences prefs)
         if (_descPreview is not null)
             ImGui.InputTextMultiline("leveldesc##preview", ref _descPreview, uint.MaxValue, new Vector2(-1, ImGui.GetTextLineHeight() * PREVIEW_SIZE));
         else if (ImGui.Button("Generate preview"))
-            _descPreview = Wms2RlUtils.SerializeToString(ld);
+            _descPreview = Wms2RlUtils.SerializeToString(ld, bhstyle: true);
 
         if (ImGui.Button("Export"))
         {
@@ -215,7 +215,7 @@ public class ExportWindow(PathPreferences prefs)
                 DialogResult result = Dialog.FileSave("xml", Path.GetDirectoryName(prefs.LevelDescPath));
                 if (result.IsOk)
                 {
-                    Wms2RlUtils.SerializeToPath(ld, result.Path);
+                    Wms2RlUtils.SerializeToPath(ld, result.Path, bhstyle: true);
                     prefs.LevelDescPath = result.Path;
                     _exportError = null;
                 }
@@ -232,7 +232,7 @@ public class ExportWindow(PathPreferences prefs)
         if (_typePreview is not null)
             ImGui.InputTextMultiline("leveltype##preview", ref _typePreview, uint.MaxValue, new Vector2(-1, ImGui.GetTextLineHeight() * PREVIEW_SIZE));
         else if (ImGui.Button("Generate preview"))
-            _typePreview = Wms2RlUtils.SerializeToString(l.Type);
+            _typePreview = Wms2RlUtils.SerializeToString(l.Type, bhstyle: true);
 
         ImGui.Checkbox("Add to LevelTypes.xml", ref _addToLt);
         if (_addToLt)
@@ -258,13 +258,13 @@ public class ExportWindow(PathPreferences prefs)
                     try
                     {
                         _exportStatus = "exporting...";
-                        LevelTypes lts = Wms2RlUtils.DeserializeFromPath<LevelTypes>(prefs.LevelTypesPath!);
+                        LevelTypes lts = Wms2RlUtils.DeserializeFromPath<LevelTypes>(prefs.LevelTypesPath!, bhstyle: true);
                         if (lts.Levels.Length == 0) throw new Exception($"Could not read LevelTypes.xml from given path {prefs.LevelTypesPath}");
                         lts.AddOrUpdateLevelType(l.Type);
                         DialogResult result = Dialog.FileSave("xml", Path.GetDirectoryName(prefs.LevelTypesPath));
                         if (result.IsOk)
                         {
-                            Wms2RlUtils.SerializeToPath(lts, result.Path);
+                            Wms2RlUtils.SerializeToPath(lts, result.Path, bhstyle: true);
                             _exportError = null;
                         }
                         _exportStatus = null;
@@ -287,7 +287,7 @@ public class ExportWindow(PathPreferences prefs)
                 if (result.IsOk)
                 {
                     _exportStatus = "exporting...";
-                    Wms2RlUtils.SerializeToPath(l.Type, result.Path);
+                    Wms2RlUtils.SerializeToPath(l.Type, result.Path, bhstyle: true);
                     prefs.LevelTypePath = result.Path;
                     _exportError = null;
                     _exportStatus = null;
@@ -348,7 +348,7 @@ public class ExportWindow(PathPreferences prefs)
         uint key = Wms2RlUtils.FindDecryptionKey(abcFile) ?? throw new InvalidDataException("Could not find decryption key");
         prefs.DecryptionKey = key.ToString();
         _exportStatus = "found!";
-        string ldData = Wms2RlUtils.SerializeToString(l.Desc, true);
+        string ldData = Wms2RlUtils.SerializeToString(l.Desc, minify: true, bhstyle: true);
 
         string dynamicPath = Path.Combine(prefs.BrawlhallaPath!, "Dynamic.swz");
         string initPath = Path.Combine(prefs.BrawlhallaPath!, "Init.swz");
@@ -372,9 +372,9 @@ public class ExportWindow(PathPreferences prefs)
         Dictionary<string, string> initFiles = [];
         foreach (string content in Wms2RlUtils.GetFilesInSwz(initPath, key))
             initFiles.Add(SwzUtils.GetFileName(content), content);
-        LevelTypes lts = Wms2RlUtils.DeserializeFromString<LevelTypes>(initFiles["LevelTypes.xml"]);
+        LevelTypes lts = Wms2RlUtils.DeserializeFromString<LevelTypes>(initFiles["LevelTypes.xml"], bhstyle: true);
         lts.AddOrUpdateLevelType(l.Type ?? throw new ArgumentNullException("l.Type"));
-        initFiles["LevelTypes.xml"] = Wms2RlUtils.SerializeToString(lts, true);
+        initFiles["LevelTypes.xml"] = Wms2RlUtils.SerializeToString(lts, minify: true, bhstyle: true);
 
         Dictionary<string, string> gameFiles = [];
         foreach (string content in Wms2RlUtils.GetFilesInSwz(gamePath, key))

--- a/WallyMapSpinzor2.Raylib/src/Gui/Windows/ImportWindow.cs
+++ b/WallyMapSpinzor2.Raylib/src/Gui/Windows/ImportWindow.cs
@@ -141,7 +141,7 @@ public class ImportWindow(PathPreferences prefs)
                 _loadingStatus = "loading...";
                 try
                 {
-                    LevelDesc ld = Wms2RlUtils.DeserializeFromString<LevelDesc>(levelDescFiles[_pickedFileName!]);
+                    LevelDesc ld = Wms2RlUtils.DeserializeFromString<LevelDesc>(levelDescFiles[_pickedFileName!], bhstyle: true);
                     _loadingStatus = null;
                     _loadingError = null;
                     editor.LoadMapFromLevel(new Level(ld, _decryptedLt, _decryptedLst), _boneNames, _powerNames);
@@ -327,8 +327,8 @@ public class ImportWindow(PathPreferences prefs)
             levelDescFiles.Add(name["LevelDesc_".Length..], file);
         }
 
-        _decryptedLt = Wms2RlUtils.DeserializeSwzFromPath<LevelTypes>(initPath, "LevelTypes.xml", key);
-        _decryptedLst = Wms2RlUtils.DeserializeSwzFromPath<LevelSetTypes>(gamePath, "LevelSetTypes.xml", key);
+        _decryptedLt = Wms2RlUtils.DeserializeSwzFromPath<LevelTypes>(initPath, "LevelTypes.xml", key, bhstyle: true);
+        _decryptedLst = Wms2RlUtils.DeserializeSwzFromPath<LevelSetTypes>(gamePath, "LevelSetTypes.xml", key, bhstyle: true);
         string? boneTypesContent = Wms2RlUtils.GetFileInSwzFromPath(initPath, "BoneTypes.xml", key);
         string? powerTypesContent = Wms2RlUtils.GetFileInSwzFromPath(gamePath, "powerTypes.csv", key);
         if (boneTypesContent is null)

--- a/WallyMapSpinzor2.Raylib/src/Gui/Windows/PlaylistEditPanel.cs
+++ b/WallyMapSpinzor2.Raylib/src/Gui/Windows/PlaylistEditPanel.cs
@@ -63,7 +63,7 @@ public static class PlaylistEditPanel
                 try
                 {
                     uint key = uint.Parse(_decyptionKey!);
-                    _levelSetTypes = Wms2RlUtils.DeserializeSwzFromPath<LevelSetTypes>(_gameSwzPath!, "LevelSetTypes.xml", key);
+                    _levelSetTypes = Wms2RlUtils.DeserializeSwzFromPath<LevelSetTypes>(_gameSwzPath!, "LevelSetTypes.xml", key, bhstyle: true);
                     if (_levelSetTypes is null) throw new Exception("Could not deserialize Game.swz");
                     _allPlaylists = _levelSetTypes.Playlists.Select(lst => lst.LevelSetName).Where(p => p != "Auto").Distinct().ToArray();
                     l.Playlists = l.Playlists.Where(p => _allPlaylists.Contains(p)).ToHashSet();
@@ -94,7 +94,7 @@ public static class PlaylistEditPanel
 
             if (prefs.LevelSetTypesPath is not null && ImGui.Button("Import##lst"))
             {
-                _levelSetTypes = Wms2RlUtils.DeserializeFromPath<LevelSetTypes>(prefs.LevelSetTypesPath);
+                _levelSetTypes = Wms2RlUtils.DeserializeFromPath<LevelSetTypes>(prefs.LevelSetTypesPath, bhstyle: true);
                 _allPlaylists = _levelSetTypes.Playlists.Select(lst => lst.LevelSetName).Where(p => p != "Auto").Distinct().ToArray();
                 l.Playlists = l.Playlists.Where(p => _allPlaylists.Contains(p)).ToHashSet();
                 _playlistFilter = "";

--- a/WallyMapSpinzor2.Raylib/src/Gui/Windows/RenderConfigWindow.cs
+++ b/WallyMapSpinzor2.Raylib/src/Gui/Windows/RenderConfigWindow.cs
@@ -19,7 +19,7 @@ public class RenderConfigWindow
     {
         XElement element;
         using (FileStream stream = new(path, FileMode.Open, FileAccess.Read))
-            element = BhXmlParser.Load(stream).Elements().First();
+            element = XElement.Load(stream);
         config.Deserialize(element);
     }
 

--- a/WallyMapSpinzor2.Raylib/src/Gui/Windows/RenderConfigWindow.cs
+++ b/WallyMapSpinzor2.Raylib/src/Gui/Windows/RenderConfigWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -18,7 +19,7 @@ public class RenderConfigWindow
     {
         XElement element;
         using (FileStream stream = new(path, FileMode.Open, FileAccess.Read))
-            element = XElement.Load(path);
+            element = BhXmlParser.Load(stream).Elements().First();
         config.Deserialize(element);
     }
 

--- a/WallyMapSpinzor2.Raylib/src/Wms2RlUtils.cs
+++ b/WallyMapSpinzor2.Raylib/src/Wms2RlUtils.cs
@@ -128,28 +128,8 @@ public static class Wms2RlUtils
         return area > 0;
     }
 
-    public static T DeserializeFromPath<T>(string fromPath)
-        where T : IDeserializable, new()
-    {
-        XElement element;
-        using (FileStream fromFile = new(fromPath, FileMode.Open, FileAccess.Read))
-        {
-            // bmg moment
-            if (fromPath.EndsWith("RefineryDoors.xml"))
-            {
-                string content;
-                using (StreamReader reader = new(fromFile))
-                    content = reader.ReadToEnd();
-                content = content.Replace("--->", "-->");
-                element = XElement.Parse(content);
-            }
-            else
-            {
-                element = XElement.Load(fromFile);
-            }
-        }
-        return element.DeserializeTo<T>();
-    }
+    public static T DeserializeFromPath<T>(string fromPath) where T : IDeserializable, new() =>
+        DeserializeFromString<T>(File.ReadAllText(fromPath));
 
     public static void SerializeToPath<T>(T serializable, string toPath, bool minify = false)
         where T : ISerializable
@@ -174,9 +154,7 @@ public static class Wms2RlUtils
     public static T DeserializeFromString<T>(string xmldata)
         where T : IDeserializable, new()
     {
-        // bmg moment
-        xmldata = xmldata.Replace("--->", "-->");
-        XElement element = XElement.Parse(xmldata);
+        XElement element = BhXmlParser.Parse(xmldata).Elements().First();
         return element.DeserializeTo<T>();
     }
 

--- a/WallyMapSpinzor2.Raylib/src/Wms2RlUtils.cs
+++ b/WallyMapSpinzor2.Raylib/src/Wms2RlUtils.cs
@@ -128,34 +128,67 @@ public static class Wms2RlUtils
         return area > 0;
     }
 
-    public static T DeserializeFromPath<T>(string fromPath) where T : IDeserializable, new() =>
-        DeserializeFromString<T>(File.ReadAllText(fromPath));
+    public static T DeserializeFromPath<T>(string fromPath, bool bhstyle = false) where T : IDeserializable, new()
+    {
+        if (bhstyle)
+        {
+            return DeserializeFromString<T>(File.ReadAllText(fromPath), true);
+        }
+        else
+        {
+            using FileStream stream = new(fromPath, FileMode.Open, FileAccess.Read);
+            return XElement.Load(stream).DeserializeTo<T>();
+        }
+    }
 
-    public static void SerializeToPath<T>(T serializable, string toPath, bool minify = false)
+    public static void SerializeToPath<T>(T serializable, string toPath, bool minify = false, bool bhstyle = false)
         where T : ISerializable
     {
         XElement e = serializable.SerializeToXElement();
         using FileStream toFile = new(toPath, FileMode.Create, FileAccess.Write);
-        using XmlWriter xmlw = XmlWriter.Create(toFile, minify ? MinifiedSaveSettings : StandardSaveSettings);
-        e.Save(xmlw);
+        if (bhstyle)
+        {
+            string str = BhXmlPrinter.Print(e, !minify);
+            using StreamWriter writer = new(toFile);
+            writer.Write(str);
+        }
+        else
+        {
+            using XmlWriter writer = XmlWriter.Create(toFile, minify ? MinifiedSaveSettings : StandardSaveSettings);
+            e.Save(writer);
+        }
     }
 
-    public static string SerializeToString<T>(T serializable, bool minify = false)
+    public static string SerializeToString<T>(T serializable, bool minify = false, bool bhstyle = false)
         where T : ISerializable
     {
         XElement e = serializable.SerializeToXElement();
-        using StringWriter sw = new();
-        using XmlWriter xmlw = XmlWriter.Create(sw, minify ? MinifiedSaveSettings : StandardSaveSettings);
-        e.Save(xmlw);
-        xmlw.Flush();
-        return sw.ToString();
+        if (bhstyle)
+        {
+            return BhXmlPrinter.Print(e, !minify);
+        }
+        else
+        {
+            using StringWriter sw = new();
+            using XmlWriter writer = XmlWriter.Create(sw, minify ? MinifiedSaveSettings : StandardSaveSettings);
+            e.Save(writer);
+            writer.Flush();
+            return sw.ToString();
+        }
     }
 
-    public static T DeserializeFromString<T>(string xmldata)
+    public static T DeserializeFromString<T>(string xmldata, bool bhstyle = false)
         where T : IDeserializable, new()
     {
-        XElement element = BhXmlParser.Parse(xmldata).Elements().First();
-        return element.DeserializeTo<T>();
+        if (bhstyle)
+        {
+            XElement element = BhXmlParser.Parse(xmldata).Elements().First();
+            return element.DeserializeTo<T>();
+        }
+        else
+        {
+            return XElement.Parse(xmldata).DeserializeTo<T>();
+        }
     }
 
     public static IEnumerable<string> GetFilesInSwz(string swzPath, uint key)
@@ -169,12 +202,12 @@ public static class Wms2RlUtils
     public static string? GetFileInSwzFromPath(string swzPath, string filename, uint key) =>
         GetFilesInSwz(swzPath, key).FirstOrDefault(file => SwzUtils.GetFileName(file) == filename);
 
-    public static T? DeserializeSwzFromPath<T>(string swzPath, string filename, uint key)
+    public static T? DeserializeSwzFromPath<T>(string swzPath, string filename, uint key, bool bhstyle = false)
         where T : IDeserializable, new()
     {
         string? content = GetFileInSwzFromPath(swzPath, filename, key);
         if (content is null) return default;
-        return DeserializeFromString<T>(content);
+        return DeserializeFromString<T>(content, bhstyle);
     }
 
     public static void SerializeSwzFilesToPath(string swzPath, IEnumerable<string> swzFiles, uint key)

--- a/WallyMapSpinzor2.Raylib/src/Xml/BhXmlException.cs
+++ b/WallyMapSpinzor2.Raylib/src/Xml/BhXmlException.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace WallyMapSpinzor2.Raylib;
+
+[Serializable]
+public class BhXmlException : Exception
+{
+    public BhXmlException() { }
+    public BhXmlException(string message) : base(message) { }
+    public BhXmlException(string message, Exception inner) : base(message, inner) { }
+    public BhXmlException(string message, string xml, int position) : base(CreateMessage(message, xml, position)) { }
+    public BhXmlException(string message, string xml, int position, Exception inner) : base(CreateMessage(message, xml, position), inner) { }
+
+    private static string CreateMessage(string message, string xml, int position)
+    {
+        int lineNumber = 1;
+        int positionAtLine = 0;
+        for (int i = 0; i < position; ++i)
+        {
+            char c = xml[i];
+            if (c == 10)
+            {
+                lineNumber++;
+                positionAtLine = 0;
+            }
+            else if (c != 13)
+            {
+                positionAtLine++;
+            }
+        }
+
+        return $"{nameof(BhXmlException)}: {message} at line {lineNumber} char {positionAtLine}";
+    }
+}

--- a/WallyMapSpinzor2.Raylib/src/Xml/BhXmlParser.cs
+++ b/WallyMapSpinzor2.Raylib/src/Xml/BhXmlParser.cs
@@ -11,14 +11,13 @@ namespace WallyMapSpinzor2.Raylib;
 // which is the parser brawlhalla uses
 public static class BhXmlParser
 {
-    private static readonly FrozenDictionary<string, char> ESCAPES = new Dictionary<string, char>
-    {
-        ["lt"] = '<',
-        ["gt"] = '>',
-        ["amp"] = '&',
-        ["quot"] = '"',
-        ["apos"] = '\'',
-    }.ToFrozenDictionary();
+    private static readonly FrozenDictionary<string, char> ESCAPES = ((KeyValuePair<string, char>[])[
+        new("lt", '<'),
+        new("gt", '>'),
+        new("amp", '&'),
+        new("quot", '"'),
+        new("apos", '\''),
+    ]).ToFrozenDictionary();
 
     private static void AddChild(this XNode e, XNode c)
     {

--- a/WallyMapSpinzor2.Raylib/src/Xml/BhXmlParser.cs
+++ b/WallyMapSpinzor2.Raylib/src/Xml/BhXmlParser.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+
+namespace WallyMapSpinzor2.Raylib;
+
+// ported from: https://github.com/HaxeFoundation/haxe/blob/development/std/haxe/xml/Parser.hx
+// which is the parser brawlhalla uses
+
+// for some reason there is only XCData, and no XPCData, so this port does not properly parse PCData
+public static class BhXmlParser
+{
+    private static readonly FrozenDictionary<string, char> ESCAPES = new Dictionary<string, char>
+    {
+        ["lt"] = '<',
+        ["gt"] = '>',
+        ["amp"] = '&',
+        ["quot"] = '"',
+        ["apos"] = '\'',
+    }.ToFrozenDictionary();
+
+    private static void AddChild(this XNode e, XNode c)
+    {
+        if (e is XElement ee)
+            ee.Add(c);
+        else if (e is XDocument ed)
+            ed.Add(c);
+        else
+            throw new BhXmlException($"Bad node type, expected Element or Document but found {e.GetType().Name}");
+    }
+
+    private static bool Exists(this XNode e, string attribute)
+    {
+        if (e is not XElement ee)
+            throw new BhXmlException($"Bad node type, expected Element but found {e.GetType().Name}");
+        return ee.HasAttribute(attribute);
+    }
+
+    private static void Set(this XNode e, string key, string? value)
+    {
+        if (e is not XElement ee)
+            throw new BhXmlException($"Bad node type, expected Element but found {e.GetType().Name}");
+        ee.SetAttributeValue(key, value);
+    }
+
+    private enum S
+    {
+        IGNORE_SPACES,
+        BEGIN,
+        BEGIN_NODE,
+        TAG_NAME,
+        BODY,
+        ATTRIB_NAME,
+        EQUALS,
+        ATTVAL_BEGIN,
+        ATTRIB_VAL,
+        CHILDS,
+        CLOSE,
+        WAIT_END,
+        WAIT_END_RET,
+        PCDATA,
+        HEADER,
+        COMMENT,
+        DOCTYPE,
+        CDATA,
+        ESCAPE,
+    }
+
+    public static XDocument Load(Stream stream, bool strict = false)
+    {
+        string str;
+        using (StreamReader sstream = new(stream))
+            str = sstream.ReadToEnd();
+        return Parse(str, strict);
+    }
+
+    public static XDocument Parse(string str, bool strict = false)
+    {
+        XDocument doc = new();
+        DoParse(str, strict, 0, doc);
+        return doc;
+    }
+
+    private static int DoParse(string str, bool strict, int p = 0, XNode? parent = null)
+    {
+        XNode? xml = null;
+        S state = S.BEGIN;
+        S next = S.BEGIN;
+        string? aname = null;
+        int start = 0;
+        int nsubs = 0;
+        int nbrackets = 0;
+        StringBuilder? buf = new();
+        // need extra state because next is in use
+        S escapeNext = S.BEGIN;
+        int attrValQuote = -1;
+
+        while (p < str.Length)
+        {
+            char c = str[p];
+            switch (state)
+            {
+                case S.IGNORE_SPACES:
+                    switch (c)
+                    {
+                        case '\n' or '\r' or '\t' or ' ':
+                            break;
+                        default:
+                            state = next;
+                            continue;
+                    }
+                    break;
+                case S.BEGIN:
+                    switch (c)
+                    {
+                        case '<':
+                            state = S.IGNORE_SPACES;
+                            next = S.BEGIN_NODE;
+                            break;
+                        default:
+                            start = p;
+                            state = S.PCDATA;
+                            continue;
+                    }
+                    break;
+                case S.PCDATA:
+                    if (c == '<')
+                    {
+                        buf.Append(str, start, p - start);
+                        // FIXME: should be PCData
+                        XNode child = new XCData(buf.ToString());
+                        buf.Clear();
+                        parent!.AddChild(child);
+                        nsubs++;
+                        state = S.IGNORE_SPACES;
+                        next = S.BEGIN_NODE;
+                    }
+                    else if (c == '&')
+                    {
+                        buf.Append(str, start, p - start);
+                        state = S.ESCAPE;
+                        escapeNext = S.PCDATA;
+                        start = p + 1;
+                    }
+                    break;
+                case S.CDATA:
+                    if (c == ']' && str[p + 1] == ']' && str[p + 2] == '>')
+                    {
+                        XNode child = new XCData(str[start..p]);
+                        parent!.AddChild(child);
+                        nsubs++;
+                        p += 2;
+                        state = S.BEGIN;
+                    }
+                    break;
+                case S.BEGIN_NODE:
+                    switch (c)
+                    {
+                        case '!':
+                            if (str[p + 1] == '[')
+                            {
+                                p += 2;
+                                if (!str.Substring(p, 6).Equals("CDATA[", StringComparison.InvariantCultureIgnoreCase))
+                                    throw new BhXmlException("Expected <![CDATA[", str, p);
+                                p += 5;
+                                state = S.CDATA;
+                                start = p + 1;
+                            }
+                            else if (str[p + 1] == 'D' || str[p + 1] == 'd')
+                            {
+                                if (!str.Substring(p + 2, 6).Equals("OCTYPE", StringComparison.InvariantCultureIgnoreCase))
+                                    throw new BhXmlException("Expected <!DOCTYPE", str, p);
+                                p += 8;
+                                state = S.DOCTYPE;
+                                start = p + 1;
+                            }
+                            else if (str[p + 1] != '-' || str[p + 2] != '-')
+                                throw new BhXmlException("Expected <!--", str, p);
+                            else
+                            {
+                                p += 2;
+                                state = S.COMMENT;
+                                start = p + 1;
+                            }
+                            break;
+                        case '?':
+                            state = S.HEADER;
+                            start = p;
+                            break;
+                        case '/':
+                            if (parent == null)
+                                throw new BhXmlException("Expected node name", str, p);
+                            start = p + 1;
+                            state = S.IGNORE_SPACES;
+                            next = S.CLOSE;
+                            break;
+                        default:
+                            state = S.TAG_NAME;
+                            start = p;
+                            continue;
+                    }
+                    break;
+                case S.TAG_NAME:
+                    if (!IsValidChar(c))
+                    {
+                        if (p == start)
+                            throw new BhXmlException("Expected node name", str, p);
+                        xml = new XElement(str[start..p]);
+                        parent!.AddChild(xml);
+                        nsubs++;
+                        state = S.IGNORE_SPACES;
+                        next = S.BODY;
+                        continue;
+                    }
+                    break;
+                case S.BODY:
+                    switch (c)
+                    {
+                        case '/':
+                            state = S.WAIT_END;
+                            break;
+                        case '>':
+                            state = S.CHILDS;
+                            break;
+                        default:
+                            state = S.ATTRIB_NAME;
+                            start = p;
+                            continue;
+                    }
+                    break;
+                case S.ATTRIB_NAME:
+                    if (!IsValidChar(c))
+                    {
+                        if (start == p)
+                            throw new BhXmlException("Expected attribute name", str, p);
+                        string tmp = str[start..p];
+                        aname = tmp;
+                        if (xml!.Exists(aname))
+                            throw new BhXmlException("Duplicate attribute [" + aname + "]", str, p);
+                        state = S.IGNORE_SPACES;
+                        next = S.EQUALS;
+                        continue;
+                    }
+                    break;
+                case S.EQUALS:
+                    switch (c)
+                    {
+                        case '=':
+                            state = S.IGNORE_SPACES;
+                            next = S.ATTVAL_BEGIN;
+                            break;
+                        default:
+                            throw new BhXmlException("Expected =", str, p);
+                    }
+                    break;
+                case S.ATTVAL_BEGIN:
+                    switch (c)
+                    {
+                        case '"' or '\'':
+                            buf.Clear();
+                            state = S.ATTRIB_VAL;
+                            start = p + 1;
+                            attrValQuote = c;
+                            break;
+                        default:
+                            throw new BhXmlException("Expected \"", str, p);
+                    }
+                    break;
+                case S.ATTRIB_VAL:
+                    switch (c)
+                    {
+                        case '&':
+                            buf.Append(str, start, p - start);
+                            state = S.ESCAPE;
+                            escapeNext = S.ATTRIB_VAL;
+                            start = p + 1;
+                            break;
+                        case '>' or '<' when strict:
+                            // HTML allows these in attributes values
+                            throw new BhXmlException("Invalid unescaped " + c + " in attribute value", str, p);
+                        default:
+                            if (c == attrValQuote)
+                            {
+                                buf.Append(str, start, p - start);
+                                string val = buf.ToString();
+                                buf.Clear();
+                                xml!.Set(aname!, val);
+                                state = S.IGNORE_SPACES;
+                                next = S.BODY;
+                            }
+                            break;
+                    }
+                    break;
+                case S.CHILDS:
+                    p = DoParse(str, strict, p, xml);
+                    start = p;
+                    state = S.BEGIN;
+                    break;
+                case S.WAIT_END:
+                    state = c switch
+                    {
+                        '>' => S.BEGIN,
+                        _ => throw new BhXmlException("Expected >", str, p),
+                    };
+                    break;
+                case S.WAIT_END_RET:
+                    switch (c)
+                    {
+                        case '>':
+                            if (nsubs == 0)
+                                // FIXME: should be PCData
+                                parent!.AddChild(new XCData(""));
+                            return p;
+                        default:
+                            throw new BhXmlException("Expected >", str, p);
+                    }
+                case S.CLOSE:
+                    if (!IsValidChar(c))
+                    {
+                        if (start == p)
+                            throw new BhXmlException("Expected node name", str, p);
+
+                        string v = str[start..p];
+                        if (parent is null || parent is not XElement eparent)
+                            throw new BhXmlException($"Unexpected </{v}>, tag is not open", str, p);
+                        if (v != eparent.Name)
+                            throw new BhXmlException("Expected </" + eparent.Name + ">", str, p);
+                        state = S.IGNORE_SPACES;
+                        next = S.WAIT_END_RET;
+                        continue;
+                    }
+                    break;
+                case S.COMMENT:
+                    if (c == '-' && str[p + 1] == '-' && str[p + 2] == '>')
+                    {
+                        parent!.AddChild(new XComment(str[start..p]));
+                        nsubs++;
+                        p += 2;
+                        state = S.BEGIN;
+                    }
+                    break;
+                case S.DOCTYPE:
+                    if (c == '[')
+                        nbrackets++;
+                    else if (c == ']')
+                        nbrackets--;
+                    else if (c == '>' && nbrackets == 0)
+                    {
+                        parent!.AddChild(new XDocumentType(str[start..p], null, null, null));
+                        nsubs++;
+                        state = S.BEGIN;
+                    }
+                    break;
+                case S.HEADER:
+                    if (c == '?' && str[p + 1] == '>')
+                    {
+                        p++;
+                        parent!.AddChild(new XProcessingInstruction("", str.Substring(start + 1, p - start - 2)));
+                        nsubs++;
+                        state = S.BEGIN;
+                    }
+                    break;
+                case S.ESCAPE:
+                    if (c == ';')
+                    {
+                        string s = str[start..p];
+                        if (s[0] == '#')
+                        {
+                            buf.Append((char)int.Parse(s[1] == 'x' ? $"0{s[1..]}" : s[1..]));
+                        }
+                        else if (!ESCAPES.TryGetValue(s, out char value))
+                        {
+                            if (strict)
+                                throw new BhXmlException("Undefined entity: " + s, str, p);
+                            buf.Append($"&{s};");
+                        }
+                        else
+                        {
+                            buf.Append(value);
+                        }
+                        start = p + 1;
+                        state = escapeNext;
+                    }
+                    else if (!IsValidChar(c) && c != '#')
+                    {
+                        if (strict)
+                            throw new BhXmlException("Invalid character in entity: " + c, str, p);
+                        buf.Append('&');
+                        buf.Append(str, start, p - start);
+                        p--;
+                        start = p + 1;
+                        state = escapeNext;
+                    }
+                    break;
+            }
+            ++p;
+        }
+
+        if (state == S.BEGIN)
+        {
+            start = p;
+            state = S.PCDATA;
+        }
+
+        if (state == S.PCDATA)
+        {
+            if (parent is XElement eparent)
+                throw new BhXmlException("Unclosed node <" + eparent.Name + ">", str, p);
+            if (p != start || nsubs == 0)
+            {
+                buf.Append(str, start, p - start);
+                // FIXME: should be PCData
+                parent!.AddChild(new XCData(buf.ToString()));
+            }
+            return p;
+        }
+
+        if (!strict && state == S.ESCAPE && escapeNext == S.PCDATA)
+        {
+            buf.Append('&');
+            buf.Append(str, start, p - start);
+            // FIXME: should be PCData
+            parent!.AddChild(new XCData(buf.ToString()));
+            return p;
+        }
+
+        throw new BhXmlException("Unexpected end", str, p);
+    }
+
+    private static bool IsValidChar(char c)
+    {
+        return
+            (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') ||
+            c == ':' ||
+            c == '.' ||
+            c == '_' ||
+            c == '-';
+    }
+}

--- a/WallyMapSpinzor2.Raylib/src/Xml/BhXmlParser.cs
+++ b/WallyMapSpinzor2.Raylib/src/Xml/BhXmlParser.cs
@@ -9,8 +9,6 @@ namespace WallyMapSpinzor2.Raylib;
 
 // ported from: https://github.com/HaxeFoundation/haxe/blob/development/std/haxe/xml/Parser.hx
 // which is the parser brawlhalla uses
-
-// for some reason there is only XCData, and no XPCData, so this port does not properly parse PCData
 public static class BhXmlParser
 {
     private static readonly FrozenDictionary<string, char> ESCAPES = new Dictionary<string, char>
@@ -130,8 +128,7 @@ public static class BhXmlParser
                     if (c == '<')
                     {
                         buf.Append(str, start, p - start);
-                        // FIXME: should be PCData
-                        XNode child = new XCData(buf.ToString());
+                        XNode child = new XText(buf.ToString());
                         buf.Clear();
                         parent!.AddChild(child);
                         nsubs++;
@@ -311,8 +308,7 @@ public static class BhXmlParser
                     {
                         case '>':
                             if (nsubs == 0)
-                                // FIXME: should be PCData
-                                parent!.AddChild(new XCData(""));
+                                parent!.AddChild(new XText(""));
                             return p;
                         default:
                             throw new BhXmlException("Expected >", str, p);
@@ -412,8 +408,7 @@ public static class BhXmlParser
             if (p != start || nsubs == 0)
             {
                 buf.Append(str, start, p - start);
-                // FIXME: should be PCData
-                parent!.AddChild(new XCData(buf.ToString()));
+                parent!.AddChild(new XText(buf.ToString()));
             }
             return p;
         }
@@ -422,8 +417,7 @@ public static class BhXmlParser
         {
             buf.Append('&');
             buf.Append(str, start, p - start);
-            // FIXME: should be PCData
-            parent!.AddChild(new XCData(buf.ToString()));
+            parent!.AddChild(new XText(buf.ToString()));
             return p;
         }
 

--- a/WallyMapSpinzor2.Raylib/src/Xml/BhXmlPrinter.cs
+++ b/WallyMapSpinzor2.Raylib/src/Xml/BhXmlPrinter.cs
@@ -1,0 +1,166 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace WallyMapSpinzor2.Raylib;
+
+public partial class BhXmlPrinter
+{
+    public static string Print(XNode xml, bool pretty = false)
+    {
+        BhXmlPrinter printer = new(pretty);
+        printer.WriteNode(xml, "");
+        return printer._output.ToString();
+    }
+
+    private readonly StringBuilder _output = new();
+    private readonly bool _pretty;
+
+    private BhXmlPrinter(bool pretty)
+    {
+        _pretty = pretty;
+    }
+
+    private static string HtmlEscape(string s, bool quotes = false)
+    {
+        StringBuilder buf = new();
+        foreach (char c in s)
+            switch (c)
+            {
+                case '&':
+                    buf.Append("&amp;");
+                    break;
+                case '<':
+                    buf.Append("&lt;");
+                    break;
+                case '>':
+                    buf.Append("&gt;");
+                    break;
+                case '"':
+                    if (quotes)
+                        buf.Append("&quot;");
+                    break;
+                case '\'':
+                    if (quotes)
+                        buf.Append("&#039;");
+                    break;
+                default:
+                    buf.Append(c);
+                    break;
+            }
+        return buf.ToString();
+    }
+
+    private void WriteNode(XNode value, string tabs)
+    {
+        if (value is XCData cdata)
+        {
+            Write(tabs + "<![CDATA[");
+            Write(cdata.Value);
+            Write("]]>");
+            Newline();
+        }
+        else if (value is XComment comment)
+        {
+            string commentContent = comment.Value;
+            commentContent = CommentRegex.Replace(commentContent, "");
+            commentContent = "<!--" + commentContent + "-->";
+            Write(tabs);
+            Write(commentContent.Trim());
+            Newline();
+        }
+        else if (value is XDocument document)
+        {
+            foreach (XNode node in document.Nodes())
+                WriteNode(node, tabs);
+        }
+        else if (value is XElement element)
+        {
+            Write(tabs + "<");
+            Write(element.Name.LocalName);
+            foreach (XAttribute attribute in element.Attributes())
+            {
+                Write(" " + attribute.Name.LocalName + "=\"");
+                Write(HtmlEscape(attribute.Value, true));
+                Write("\"");
+            }
+            if (HasChildren(element))
+            {
+                Write(">");
+                Newline();
+                foreach (XNode child in element.Nodes())
+                {
+                    WriteNode(child, _pretty ? tabs + "\t" : tabs);
+                }
+                Write(tabs + "</");
+                Write(element.Name.LocalName);
+                Write(">");
+                Newline();
+            }
+            else
+            {
+                Write("/>");
+                Newline();
+            }
+        }
+        else if (value is XText pcdata)
+        {
+            if (pcdata.Value.Length != 0)
+            {
+                Write(tabs + HtmlEscape(pcdata.Value));
+                Newline();
+            }
+        }
+        else if (value is XProcessingInstruction proc)
+        {
+            Write("<?" + proc.Data + "?>");
+            Newline();
+        }
+        else if (value is XDocumentType type)
+        {
+            Write("<!DOCTYPE " + type.Name + ">");
+            Newline();
+        }
+    }
+
+    private void Write(string input)
+    {
+        _output.Append(input);
+    }
+
+    private void Newline()
+    {
+        if (_pretty)
+        {
+            _output.Append('\n');
+        }
+    }
+
+    private static bool HasChildren(XNode node)
+    {
+        if (node is not XContainer container)
+            return false;
+        foreach (XNode child in container.Nodes())
+        {
+            if (child is XElement)
+                return true;
+            else if (child is XCData cdata)
+            {
+                if (cdata.Value.TrimStart().Length != 0)
+                    return true;
+            }
+            else if (child is XComment comment)
+            {
+                if (comment.Value.TrimStart().Length != 0)
+                    return true;
+            }
+            else if (child is XText)
+                return true;
+        }
+        return false;
+    }
+
+    private static readonly Regex CommentRegex = CommentRegexGenerator();
+    [GeneratedRegex("[\n\r\t]+")]
+    private static partial Regex CommentRegexGenerator();
+}


### PR DESCRIPTION
Implement Brawlhalla's xml parsing and printing (which are just from the haxe stl). Use for brawlhalla xmls.

Xmls for our use, such as render config, still use the .NET parser/printer.